### PR TITLE
Se añade parámetro numEsperadoJugadores al método constructor de laOca

### DIFF
--- a/server/laOca.js
+++ b/server/laOca.js
@@ -78,13 +78,13 @@ function CasillasFactory() {
     }
 }
 
-function LaOca(tablero, coleccionFichas) {
+function LaOca(tablero, coleccionFichas, numRequeridoJugadores) {
     this.tablero = tablero;
     this.coleccionFichas = coleccionFichas;
     this.coleccionJugadores = [];
     this.turno = undefined;
     this.fase = undefined;
-    this.numeroJugadores = undefined;
+    this.numeroJugadores = numRequeridoJugadores;
 
     this.asignarFicha = function (jugador) {
         this.fase.asignarFicha(jugador);


### PR DESCRIPTION
De esta forma podrían crearse partidas con un número de jugadores requerido ya establecido, sin necesidad de indicarlo después.